### PR TITLE
Dev track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ venv.bak/
 
 tmp/
 
+## VSCODE
+.vscode/
+
 ## Example files
 examples/psychopy/data/
 examples/psychopy/demo_lastrun.py

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ tmp/
 ## VSCODE
 .vscode/
 
+## Testing code
+*playground*
+
 ## Example files
 examples/psychopy/data/
 examples/psychopy/demo_lastrun.py

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "python.pythonPath": "venv\\Scripts\\python.exe"
-}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Use `pylint motbox/*.py` or `pylint motbox/yourfile.py`
 ## Unit tests
 
 Use `python -m unittest discover test` at top folder level.
+
+Running a single test is also possible `python -m unittest test.test_track.TestTrack.test_generate_vonmises.` But beware that the test file includes COMPLETE parameter which by defaults skips those functionw which take a long time to finish (video or track generations).

--- a/README.md
+++ b/README.md
@@ -4,11 +4,22 @@ Python code for preparing and presenting [Multiple Object Tracking](http://www.s
 
 ## How to use it
 
-Look inside the `examples` folder for an example of [PsychoPy](https://www.psychopy.org/) integration.
+This package can be used either as a controller for psychopy objects (see `Pupeteer` class in `motbox.control`) or as a generator for paths. These generated paths can then be loaded and used for controlled, pre-reandomised administration of tracks.
 
-Currently the package is tested and working with pscyhopy 1.9 and Python 2.
+### Psychopy
+Look inside the `examples` folder for an example of [PsychoPy](https://www.psychopy.org/) integration. 
 
-## Code
+Currently the package is tested and working with psychopy 1.9 and Python 2.
+
+### Generators
+Path generation can be done either by your own scripts using the `Position` class to generate starting positions and `Track` to then `generate_trajectory`, or there are some shorthand functions in the `motbox.generator` file.
+
+### Command line
+Installation of the package comes with some command line options to generate tracks. If you have installed the package with pip, you can do following commands from command line:
+
+`generate-straight-trajectory --help`
+
+## Code revision
 
 Use `pylint motbox/*.py` or `pylint motbox/yourfile.py`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Currently the package is tested and working with psychopy 1.9 and Python 2.
 ### Generators
 Path generation can be done either by your own scripts using the `Position` class to generate starting positions and `Track` to then `generate_trajectory`, or there are some shorthand functions in the `motbox.generator` file.
 
+### Visualisations
+the `motbox.visualisaions` contains function `plot` allowing to plot position data and/or trajectory data and a function `trajectory_video` which makes a video out of a valid `Trajectory` object.
+
 ### Command line
 Installation of the package comes with some command line options to generate tracks. If you have installed the package with pip, you can do following commands from command line:
 

--- a/motbox/__init__.py
+++ b/motbox/__init__.py
@@ -6,4 +6,3 @@ __all__ = ["Track", "Position", "Puppeteer"]
 
 from .track import Track, Position
 from .control import Puppeteer
-from .generator import generate_straight_trajectory

--- a/motbox/__init__.py
+++ b/motbox/__init__.py
@@ -6,3 +6,5 @@ __all__ = ["Track", "Position", "Puppeteer"]
 
 from .track import Track, Position
 from .control import Puppeteer
+from .commands import generate_straight_trajectory
+from .generator import generate_straight_trajectory

--- a/motbox/__init__.py
+++ b/motbox/__init__.py
@@ -6,5 +6,4 @@ __all__ = ["Track", "Position", "Puppeteer"]
 
 from .track import Track, Position
 from .control import Puppeteer
-from .commands import generate_straight_trajectory
 from .generator import generate_straight_trajectory

--- a/motbox/commands.py
+++ b/motbox/commands.py
@@ -16,4 +16,5 @@ from motbox.generator import generate_straight_trajectory as gst
 def generate_straight_trajectory(path, filename, n, speed, time, frequency, xlim, ylim, plot, video):
 	filepath = os.path.join(path, filename)
 	click.echo(f'Saving to {filepath}.csv')
-	gst(path, filename, n, speed, time, frequency, xlim, ylim, plot, video)
+	gst(n=n, speed=speed, time=time, frequency=frequency,
+    xlim=xlim, ylim=ylim, save=True, path=path, filename=filename, plot=plot, video=video)

--- a/motbox/commands.py
+++ b/motbox/commands.py
@@ -3,7 +3,7 @@ import click
 from motbox.generator import generate_straight_trajectory as gst
 
 @click.command()
-@click.argument('path', type=click.Path(exists=True))
+@click.argument('path', type=click.Path(exists=True, dir_okay=True, file_okay=False))
 @click.option('-f', '--filename', default='track', type=str)
 @click.option('-n', '--n', default=1, type=int)
 @click.option('-s', '--speed', default=1, type=float)
@@ -14,5 +14,6 @@ from motbox.generator import generate_straight_trajectory as gst
 @click.option('--plot', default=False, type=bool)
 @click.option('--video', default=False, type=bool)
 def generate_straight_trajectory(path, filename, n, speed, time, frequency, xlim, ylim, plot, video):
-  gst(path, filename, n, speed, time, frequency, xlim, ylim, plot, video)
-  
+	filepath = os.path.join(path, filename)
+	click.echo(f'Saving to {filepath}.csv')
+	gst(path, filename, n, speed, time, frequency, xlim, ylim, plot, video)

--- a/motbox/commands.py
+++ b/motbox/commands.py
@@ -1,0 +1,18 @@
+import os
+import click
+from motbox.generator import generate_straight_trajectory as gst
+
+@click.command()
+@click.argument('path', type=click.Path(exists=True))
+@click.option('-f', '--filename', default='track', type=str)
+@click.option('-n', '--n', default=1, type=int)
+@click.option('-s', '--speed', default=1, type=float)
+@click.option('-fr', '--frequency', default=10, type=int)
+@click.option('-x', '--xlim', default=(-10,10), type=(float, float))
+@click.option('-y', '--ylim', default=(-10,10), type=(float, float))
+@click.option('-t', '--time', default=5, type=float)
+@click.option('--plot', default=False, type=bool)
+@click.option('--video', default=False, type=bool)
+def generate_straight_trajectory(path, filename, n, speed, time, frequency, xlim, ylim, plot, video):
+  gst(path, filename, n, speed, time, frequency, xlim, ylim, plot, video)
+  

--- a/motbox/generator.py
+++ b/motbox/generator.py
@@ -37,8 +37,7 @@ def generate_straight_trajectory(path, filename='track', n=1, speed=1, time=5, f
 	---------
 	This function is basically just a wrapper around motbox.Track.generate_tracjectory
 	"""
-	dirpath = os.path.dirname(os.path.realpath(path))
-	filepath = os.path.join(dirpath, filename)
+	filepath = os.path.join(path, filename)
 	## generate random start
 	position = Position()
 	position.random_positions(n, xlim, ylim, 1)
@@ -46,7 +45,6 @@ def generate_straight_trajectory(path, filename='track', n=1, speed=1, time=5, f
 	## generate path
 	track = Track()
 	track.generate_trajectory(position, speed, {"xlim": xlim, "ylim": ylim, "spacing": 1}, time = np.arange(0, time, 1/frequency))
-	print(f'saving to {filepath}.csv')
 	track.save_to_csv(f'{filepath}.csv')
 
 	## generate image and video

--- a/motbox/generator.py
+++ b/motbox/generator.py
@@ -3,53 +3,56 @@ import numpy as np
 from motbox import Track, Position
 
 
-def generate_straight_trajectory(n=1, speed=1, time=5, frequency=10, xlim=(-10,10), ylim=(-10,10), save=True, path='.', filename='track', plot=False, video=False):
-	"""Generates straight trajectory at random starting points.
-	returns the trajectory as a csv, and then saves a plot and video if wanted
+def generate_straight_trajectory(n=1, speed=1, time=5, frequency=10, xlim=(-10,10), ylim=(-10,10), spacing=1,
+  save=True, path='.', filename='track', plot=False, video=False):
+  """Generates straight trajectory at random starting points.
+  returns the trajectory as a csv, and then saves a plot and video if wanted
 
-	Parameters
-	----------
-	n : int
-		number of objects to be moved
-	speed : float or tuple of floats
-		how far will the object move each "tick". Dependent on the length of the time parameter. If touple, it needs to have the same length as
-		is the number of positions. Allows separate speeds to be applied to each object. e.g. (speed for first object, speed for second, etc.)
-	time : float
-		time of the 
-	frequency : int
-		frequency at which to 
-	xlim : tuple of floats (-10, 10)
-		limits of the box in which the objects move
-	ylim : tuple of floats (-10, 10)
-		limits of the box in which the objects move 
+  Parameters
+  ----------
+  n : int
+    number of objects to be moved
+  speed : float or tuple of floats
+    how far will the object move each "tick". Dependent on the length of the time parameter. If touple, it needs to have the same length as
+    is the number of positions. Allows separate speeds to be applied to each object. e.g. (speed for first object, speed for second, etc.)
+  time : float
+    time of the 
+  frequency : int
+    frequency at which to 
+  xlim : tuple of floats (-10, 10)
+    limits of the box in which the objects move
+  ylim : tuple of floats (-10, 10)
+    limits of the box in which the objects move
+  spacing : float (1)
+    defines spacing between objects to allow poucing from walls and from objects. Usually diameter of the object.
   save : bool (True)
     should the trajectory be saved as a csv? path and filename should be provided to override the default
-	filename : str ('track')
-		name of the file to be prepended to csv, plot and video files
-	plot : bool (False)
-		if the plot of the trajectory should be created. filename is used to determine name of the plot
-	video : bool (False)
-		if the video of the trajectory should be created. filename is used to create name of the video
+  filename : str ('track')
+    name of the file to be prepended to csv, plot and video files
+  plot : bool (False)
+    if the plot of the trajectory should be created. filename is used to determine name of the plot
+  video : bool (False)
+    if the video of the trajectory should be created. filename is used to create name of the video
 
-	Return
-	--------
-	Saves .csv file at location 
+  Return
+  --------
+  Saves .csv file at location 
 
-	See Also
-	---------
-	This function is basically just a wrapper around motbox.Track.generate_tracjectory
-	"""
-	filepath = os.path.join(path, filename)
-	## generate random start
-	position = Position()
-	position.random_positions(n, xlim, ylim, 1)
+  See Also
+  ---------
+  This function is basically just a wrapper around motbox.Track.generate_tracjectory
+  """
+  filepath = os.path.join(path, filename)
+  ## generate random start
+  position = Position()
+  position.random_positions(n, xlim, ylim, 1)
 
-	## generate path
-	track = Track()
-	track.generate_trajectory(position, speed, {"xlim": xlim, "ylim": ylim, "spacing": 1}, time = np.arange(0, time, 1/frequency))
-	if save: track.save_to_csv(f'{filepath}.csv')
-	if plot: track.plot(f"{filepath}.png", xlim, ylim)
-	if video: track.make_video(f"{filepath}.mp4", xlim, ylim)
-  
+  ## generate path
+  track = Track()
+  track.generate_trajectory(position, speed, {"xlim": xlim, "ylim": ylim, "spacing": spacing}, 
+    time = np.arange(0, time, 1/frequency))
+  if save: track.save_to_csv(f'{filepath}.csv')
+  if plot: track.plot(f"{filepath}.png", xlim, ylim)
+  if video: track.make_video(f"{filepath}.mp4", xlim, ylim)
+
   return track
- 

--- a/motbox/generator.py
+++ b/motbox/generator.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 from motbox import Track, Position
+import motbox.visualisations as vis
 
 
 def generate_straight_trajectory(n=1, speed=1, time=5, frequency=10, xlim=(-10,10), ylim=(-10,10), spacing=1,
@@ -52,7 +53,7 @@ def generate_straight_trajectory(n=1, speed=1, time=5, frequency=10, xlim=(-10,1
   track.generate_trajectory(position, speed, {"xlim": xlim, "ylim": ylim, "spacing": spacing}, 
     time = np.arange(0, time, 1/frequency))
   if save: track.save_to_csv(f'{filepath}.csv')
-  if plot: track.plot(f"{filepath}.png", xlim, ylim)
-  if video: track.make_video(f"{filepath}.mp4", xlim, ylim)
+  if plot: vis.plot(track.x, track.y, f"{filepath}.png", xlim, ylim)
+  if video: vis.trajectory_video(track, f"{filepath}.mp4", xlim, ylim)
 
   return track

--- a/motbox/generator.py
+++ b/motbox/generator.py
@@ -1,0 +1,55 @@
+import os
+import numpy as np
+from motbox import Track, Position
+
+
+def generate_straight_trajectory(path, filename='track', n=1, speed=1, time=5, frequency=10, xlim=(-10,10), ylim=(-10,10), plot=False, video=False):
+	"""Generates straight trajectory at random starting points.
+	Saves trajectory as a csv, and then saves a plot and video if wanted
+
+	Parameters
+	----------
+	filename : str ('track')
+		name of the file to be prepended to csv, plot and video files
+	n : int
+		number of objects to be moved
+	speed : float or tuple of floats
+		how far will the object move each "tick". Dependent on the length of the time parameter. If touple, it needs to have the same length as
+		is the number of positions. Allows separate speeds to be applied to each object. e.g. (speed for first object, speed for second, etc.)
+	time : float
+		time of the 
+	frequency : int
+		frequency at which to 
+	xlim : tuple of floats (-10, 10)
+		limits of the box in which the objects move
+	ylim : tuple of floats (-10, 10)
+		limits of the box in which the objects move 
+	plot : bool (False)
+		if the plot of the trajectory should be created
+	video : bool (False)
+		if the video of the trajectory should be created
+
+	Return
+	--------
+	Saves .csv file at location 
+
+	See Also
+	---------
+	This function is basically just a wrapper around motbox.Track.generate_tracjectory
+	"""
+	dirpath = os.path.dirname(os.path.realpath(path))
+	filepath = os.path.join(dirpath, filename)
+	## generate random start
+	position = Position()
+	position.random_positions(n, xlim, ylim, 1)
+
+	## generate path
+	track = Track()
+	track.generate_trajectory(position, speed, {"xlim": xlim, "ylim": ylim, "spacing": 1}, time = np.arange(0, time, 1/frequency))
+	print(f'saving to {filepath}.csv')
+	track.save_to_csv(f'{filepath}.csv')
+
+	## generate image and video
+	if plot: track.plot(f"{filepath}.png", xlim, ylim)
+	if video: track.make_video(f"{filepath}.mp4", xlim, ylim)
+ 

--- a/motbox/generator.py
+++ b/motbox/generator.py
@@ -3,14 +3,12 @@ import numpy as np
 from motbox import Track, Position
 
 
-def generate_straight_trajectory(path, filename='track', n=1, speed=1, time=5, frequency=10, xlim=(-10,10), ylim=(-10,10), plot=False, video=False):
+def generate_straight_trajectory(n=1, speed=1, time=5, frequency=10, xlim=(-10,10), ylim=(-10,10), save=True, path='.', filename='track', plot=False, video=False):
 	"""Generates straight trajectory at random starting points.
-	Saves trajectory as a csv, and then saves a plot and video if wanted
+	returns the trajectory as a csv, and then saves a plot and video if wanted
 
 	Parameters
 	----------
-	filename : str ('track')
-		name of the file to be prepended to csv, plot and video files
 	n : int
 		number of objects to be moved
 	speed : float or tuple of floats
@@ -24,10 +22,14 @@ def generate_straight_trajectory(path, filename='track', n=1, speed=1, time=5, f
 		limits of the box in which the objects move
 	ylim : tuple of floats (-10, 10)
 		limits of the box in which the objects move 
+  save : bool (True)
+    should the trajectory be saved as a csv? path and filename should be provided to override the default
+	filename : str ('track')
+		name of the file to be prepended to csv, plot and video files
 	plot : bool (False)
-		if the plot of the trajectory should be created
+		if the plot of the trajectory should be created. filename is used to determine name of the plot
 	video : bool (False)
-		if the video of the trajectory should be created
+		if the video of the trajectory should be created. filename is used to create name of the video
 
 	Return
 	--------
@@ -45,9 +47,9 @@ def generate_straight_trajectory(path, filename='track', n=1, speed=1, time=5, f
 	## generate path
 	track = Track()
 	track.generate_trajectory(position, speed, {"xlim": xlim, "ylim": ylim, "spacing": 1}, time = np.arange(0, time, 1/frequency))
-	track.save_to_csv(f'{filepath}.csv')
-
-	## generate image and video
+	if save: track.save_to_csv(f'{filepath}.csv')
 	if plot: track.plot(f"{filepath}.png", xlim, ylim)
 	if video: track.make_video(f"{filepath}.mp4", xlim, ylim)
+  
+  return track
  

--- a/motbox/track.py
+++ b/motbox/track.py
@@ -378,6 +378,7 @@ class Track(object):
         return direction
 
 
+    # TODO - redo the opts parameter, as it includes REQUIRED parameters (such as spacing), so it is not much optional
     def generate_trajectory(self, position, speed, opts, time = None, direction = None, jitter_func = None):
       """Generates trajectory for given position, speed and 
 
@@ -385,11 +386,12 @@ class Track(object):
       ---------
       position : object of class motbox.Position
         defines original starting points and number of objects. See `Position.random_position` for a generator of random startup
-      speed :
+      speed : float
+        how far will the object move each "tick". Dependent on the length of the time parameter.
       opts : dictionary with optional parameters
         currently allowed parameters are xlim, ylim, spacing. e.g. opts = {"xlim": (-10, 10), "ylim": (-10, 10), "spacing":2.}
       time : touple of float
-        array of floats to generate . e.g. range(0, 5, 0.1) for a 5s long track generated each 0.1 s. 
+        array of floats to generate . e.g. np.arange(0, 5, 0.1) for a 5s long track generated each 0.1 s. 
       direction : touple of float, optional
         defines starting direction of movement for all objects. The angle is in radians (0-2pi). (default is None, generates randomly). 
       jitter_func : function to add jitter
@@ -398,8 +400,9 @@ class Track(object):
       Returns
       ---------
       Returns self with generated track
-      
       """
+      # TODO - allow time to be passed as a number and np.arrange is run from within the function
+      # TODO - handle time is being none - it crashes
       if not time is None:
           self.time = time
       timestep = self.timestep()

--- a/motbox/track.py
+++ b/motbox/track.py
@@ -120,19 +120,19 @@ class Track(object):
         self.n_objects = 0
 
 
-    def load_from_csv(self, filename):
+    def load_from_csv(self, filename, delim="\t"):
         """Initializes object from data file.
 
         Calls classic format. Maybe add format detection in future.
         """
-        return self.load_from_csv_v0(filename)
+        return self.load_from_csv_v0(filename, delim)
 
 
-    def load_from_csv_v0(self, filename):
+    def load_from_csv_v0(self, filename, delim="\t"):
         """Initializes object from data file.
         Uses format from RepMot/RevMot studies.
         """
-        mat = np.genfromtxt(filename, delimiter='\t')
+        mat = np.genfromtxt(filename, delimiter=delim)
         # first column
 
         ncol = mat.shape[1]

--- a/motbox/track.py
+++ b/motbox/track.py
@@ -8,12 +8,6 @@ moving objects.
 import numpy as np
 from scipy.spatial import distance
 from scipy.sparse import csgraph
-import matplotlib.pyplot as plt
-
-
-from moviepy.editor import VideoClip
-from moviepy.video.io.bindings import mplfig_to_npimage
-
 
 class Position(object):
     """Represents position of n objects or one timeslice of Track
@@ -109,19 +103,7 @@ class Position(object):
             jitter = np.random.uniform(low=-amount, high=amount, size=(2, self.n_objects))
         self.move((jitter[0, :], jitter[1, :]))
 
-
-    def plot(self, filename, xlim=(-10, 10), ylim=(-10, 10)):
-        """Plots positions into file
-        """
-        plt.figure()
-        plt.plot(self.x, self.y, "o")
-        plt.xlabel = "x"
-        plt.ylabel = "y"
-        plt.xlim(xlim)
-        plt.ylim(ylim)
-        plt.savefig(filename)
-
-
+    
 class Track(object):
     """Track object
 
@@ -258,74 +240,6 @@ class Track(object):
                 self.n_objects, np.amin(self.time), np.amax(self.time))
         else:
             return "Track: NOT initialized"
-
-
-    def plot(self, filename, xlim=(-10, 10), ylim=(-10, 10)):
-        """Plots trajectories into a file. Uses matplotlib
-
-        Parameters
-        -----------
-          filename: str
-            filename for the plot o be saved into
-          xlim: touple of float 
-            x plot limits
-          ylim : touple of float
-
-        Returns
-        -------
-          Saves a png file of name filename into the working directory
-        """
-        plt.figure()
-        plt.plot(self.x, self.y, "k")
-        plt.xlabel = "x"
-        plt.ylabel = "y"
-        plt.xlim(xlim)
-        plt.ylim(ylim)
-        plt.savefig(filename)
-
-
-    def make_video(self, filename, xlim=(-10, 10), ylim=(-10, 10), callback=None, axisOff=True):
-      """Create video of the track and saves it in working directory
-
-      Parameters
-      ---------
-        filename : string 
-          name of the file to be saved into
-        xlim : touple(2) of float
-          xlimits of the fideo
-        ylim : touple(2) of float
-          ylimits of the video
-        callback:
-          what to 
-        axisOff : bool
-
-      Returns
-      --------
-      saved mp4 video at fiven filepath
-      """
-      WIDTH = 900
-      HEIGHT = 600
-      DPI = 150
-      FPS = 25
-      DURATION = np.max(self.time) - np.min(self.time)
-
-      fig, axis = plt.subplots(figsize=(1.0 * WIDTH / DPI, 1.0 * HEIGHT / DPI), dpi=DPI)
-      def make_frame(t):
-          axis.clear()
-          (tx, ty) = self.position_for_time(t + np.min(self.time))
-          axis.plot(tx, ty, "ko")
-          axis.set_xlim(xlim)
-          axis.set_ylim(ylim)
-          axis.set_title("Time {:.2f} s".format(t))
-          if not callback is None:
-              callback(axis)
-          if axisOff:
-              plt.axis('off')
-          return mplfig_to_npimage(fig)
-      animation = VideoClip(make_frame, duration=DURATION)
-      #animation.write_gif(filename, fps=FPS)
-      animation.write_videofile(filename, fps=FPS)
-      pass
 
 
     def bounce_square(self, position, direction, arena_opts):

--- a/motbox/track.py
+++ b/motbox/track.py
@@ -40,16 +40,36 @@ class Position(object):
         return np.all(dist > min_distance)
 
 
+    # TODO - potentially make this static?
     def random_positions(self, n, xlim, ylim, min_distance):
         """Populates square ares (xlim x ylim) with n objects.
         Checks minimum inter-object distance
+
+        Parameters
+        ---------
+          n : int
+            number of points to simulate
+          xlim : touple of floats (2)
+            definition of lower and upper limit of x positions
+          ylim : touple of floats (2)
+            definition of lower and upper limit of y positions
+        
+        Returns
+        -------
+        Position
+          Position object with randomly generated positions for n points
+        
+        Examples
+        -------
+        position = Position()
+        position.random_positions(5, (-10,10), (-10,10), 1)
         """
         while True:
             self.n_objects = n
             self.x = np.random.uniform(low=xlim[0], high=xlim[1], size=(n, ))
             self.y = np.random.uniform(low=ylim[0], high=ylim[1], size=(n, ))
             if self.is_min_distance_complied(min_distance):
-                break
+              break
         return self
 
 
@@ -413,6 +433,7 @@ class Track(object):
           if jitter_func is not None:
             direction += jitter_func()
       return self
+
 
     def generate_vonmises(self, position, speed, kappa, opts, time=None, direction=None):
         """Generates trajectories from starting positions and von Mises sampling

--- a/motbox/track.py
+++ b/motbox/track.py
@@ -146,6 +146,14 @@ class Track(object):
         pass
 
 
+    def save_to_csv(self, filename):
+        """Saves object's data to file
+
+        Defaults to classic format.
+        """
+        return self.save_to_csv_v0(filename)
+
+
     def save_to_csv_v0(self, filename):
         """Saves object's data to file
 
@@ -203,6 +211,15 @@ class Track(object):
 
     def position_for_time(self, timevalue):
         """Interpolates coordinates for given time point
+
+        Parameters
+        ---------
+          timevalue : float
+            time at which to interpolate the position
+
+        Returns
+        ---------
+          touple (x, y) of arrays for interpolated positions at time
         """
         n_objects = self.n_objects
         newx = np.zeros((1, n_objects))
@@ -211,14 +228,6 @@ class Track(object):
             newx[:, index] = np.interp(timevalue, self.time, self.x[:, index])
             newy[:, index] = np.interp(timevalue, self.time, self.y[:, index])
         return (newx, newy)
-
-
-    def save_to_csv(self, filename):
-        """Saves object's data to file
-
-        Defaults to classic format.
-        """
-        return self.save_to_csv_v0(filename)
 
 
     def summary(self):
@@ -232,7 +241,19 @@ class Track(object):
 
 
     def plot(self, filename, xlim=(-10, 10), ylim=(-10, 10)):
-        """Plots trajectories into a file
+        """Plots trajectories into a file. Uses matplotlib
+
+        Parameters
+        -----------
+          filename: str
+            filename for the plot o be saved into
+          xlim: touple of float 
+            x plot limits
+          ylim : touple of float
+
+        Returns
+        -------
+          Saves a png file of name filename into the working directory
         """
         plt.figure()
         plt.plot(self.x, self.y, "k")
@@ -242,7 +263,26 @@ class Track(object):
         plt.ylim(ylim)
         plt.savefig(filename)
 
+
     def make_video(self, filename, xlim=(-10, 10), ylim=(-10, 10), callback=None, axisOff=True):
+      """Create video of the track and saves it in working directory
+
+      Parameters
+      ---------
+        filename : string 
+          name of the file to be saved into
+        xlim : touple(2) of float
+          xlimits of the fideo
+        ylim : touple(2) of float
+          ylimits of the video
+        callback:
+          what to 
+        axisOff : bool
+
+      Returns
+      --------
+      saved mp4 video at fiven filepath
+      """
         WIDTH = 900
         HEIGHT = 600
         DPI = 150
@@ -270,6 +310,19 @@ class Track(object):
 
     def bounce_square(self, position, direction, arena_opts):
         """Checks for boundary bouncing and returns corrected directions
+
+        Parameters
+        ----------
+          position : object of class motbox.Position
+
+          direction : 
+
+
+          arena_opts : dictionary
+            DESCRIPTION
+
+        Returns
+
         """
         xlim = arena_opts["xlim"]
         ylim = arena_opts["ylim"]

--- a/motbox/visualisations.py
+++ b/motbox/visualisations.py
@@ -1,0 +1,77 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from moviepy.editor import VideoClip
+from moviepy.video.io.bindings import mplfig_to_npimage
+
+
+def plot(x, y, filename, xlim=(-10, 10), ylim=(-10, 10)):
+  """Plots trajectories into a file. Uses matplotlib
+
+  Parameters
+  -----------
+  x : array of float
+    x coordinates 
+  y : array of float
+    y coordinates
+  filename: str
+    filename for the plot o be saved into
+  xlim: touple of float 
+    x plot limits
+  ylim : touple of float
+
+  Returns
+  -------
+    Saves a png file of name filename into the working directory
+  """
+  plt.figure()
+  plt.plot(x, y, "k")
+  plt.xlabel = "x"
+  plt.ylabel = "y"
+  plt.xlim(xlim)
+  plt.ylim(ylim)
+  plt.savefig(filename)
+
+
+def trajectory_video(trajectory, filename, xlim=(-10, 10), ylim=(-10, 10), callback=None, axisOff=True):
+  """Create video of the track and saves it in working directory
+
+  Parameters
+  ---------
+    filename : string 
+      name of the file to be saved into
+    xlim : touple(2) of float
+      xlimits of the fideo
+    ylim : touple(2) of float
+      ylimits of the video
+    callback:
+      what to 
+    axisOff : bool
+
+  Returns
+  --------
+  saved mp4 video at fiven filepath
+  """
+  WIDTH = 900
+  HEIGHT = 600
+  DPI = 150
+  FPS = 25
+  DURATION = np.max(trajectory.time) - np.min(trajectory.time)
+
+  fig, axis = plt.subplots(figsize=(1.0 * WIDTH / DPI, 1.0 * HEIGHT / DPI), dpi=DPI)
+  def make_frame(t):
+    axis.clear()
+    (tx, ty) = trajectory.position_for_time(t + np.min(trajectory.time))
+    axis.plot(tx, ty, "ko")
+    axis.set_xlim(xlim)
+    axis.set_ylim(ylim)
+    axis.set_title("Time {:.2f} s".format(t))
+    if not callback is None:
+        callback(axis)
+    if axisOff:
+        plt.axis('off')
+    return mplfig_to_npimage(fig)
+  animation = VideoClip(make_frame, duration=DURATION)
+  #animation.write_gif(filename, fps=FPS)
+  animation.write_videofile(filename, fps=FPS)
+  pass
+

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setuptools.setup(
       'numpy>=1.16',
       'moviepy',
       'matplotlib',
-      'scipy'
+      'scipy',
+      'click'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ setuptools.setup(
       'scipy',
       'click'
     ],
+    entry_points={
+      'console_scripts': [
+        'generate-straight-trajectory = motbox.commands:generate_straight_trajectory',
+      ]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/test/test_track.py
+++ b/test/test_track.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy import testing
 from motbox import Track, Position
 
-COMPLETE = False
+COMPLETE = True
 track_data_path = os.path.join("test", "tracks", "T220.csv")
 
 class TestTrack(unittest.TestCase):
@@ -32,7 +32,6 @@ class TestTrack(unittest.TestCase):
         for f in os.listdir("test"):
             if re.search(".*(.png)|(.mp4)", f):
                 os.remove(os.path.join("test", f))
-
 
     def test_move_x(self):
         oldx = self.T1.x.copy()
@@ -65,9 +64,10 @@ class TestTrack(unittest.TestCase):
 
     @unittest.skipUnless(COMPLETE, "Time consuming video generation")
     def test_generate_vonmises(self):
-        #, position, speed, kappa, time=None, direction=None):
+        opts = {"xlim": (-10, 10), "ylim": (-10, 10), "spacing":2.}
+        time = np.arange(0, 5, 0.5)
         self.T1.generate_vonmises(
-            Position().circular_positions(8, 5), 5., 40)
+            Position().circular_positions(8, 5), speed= 3., kappa = 8, opts = opts, time = time)
         self.T1.plot(os.path.join("test", "test_generated.png"))
         self.T1.make_video(os.path.join("test", "test_generated.mp4"))
         self.assertTrue(True)

--- a/test/test_track.py
+++ b/test/test_track.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy import testing
 from motbox import Track, Position
 
-COMPLETE = True
 track_data_path = os.path.join("test", "tracks", "T220.csv")
 
 class TestTrack(unittest.TestCase):
@@ -30,7 +29,7 @@ class TestTrack(unittest.TestCase):
     def tearDown(self):
         # removes generated files so they are not left in .git by accident
         for f in os.listdir("test"):
-            if re.search(".*(.png)|(.mp4)", f):
+            if re.search(".*(.csv)", f):
                 os.remove(os.path.join("test", f))
 
     def test_move_x(self):
@@ -62,21 +61,8 @@ class TestTrack(unittest.TestCase):
         step = self.T1.timestep()
         self.assertAlmostEqual(step, 0.01)
 
-    @unittest.skipUnless(COMPLETE, "Time consuming video generation")
-    def test_generate_vonmises(self):
-        opts = {"xlim": (-10, 10), "ylim": (-10, 10), "spacing":2.}
-        time = np.arange(0, 5, 0.5)
-        self.T1.generate_vonmises(
-            Position().circular_positions(8, 5), speed= 3., kappa = 8, opts = opts, time = time)
-        self.T1.plot(os.path.join("test", "test_generated.png"))
-        self.T1.make_video(os.path.join("test", "test_generated.mp4"))
-        self.assertTrue(True)
-
-    def test_plot(self):
-        self.T1.plot(os.path.join("test", "test_trajectory.png"))
-        self.assertTrue(True)
-
-    @unittest.skipUnless(COMPLETE, "Time consuming video generation")
-    def test_make_video(self):
-        self.T1.make_video(os.path.join("test", "test_video.mp4"))
-        self.assertTrue(True)
+    def generate_vonmises(self):
+      opts = {"xlim": (-10, 10), "ylim": (-10, 10), "spacing":2.}
+      time = np.arange(0, 5, 0.5)
+      self.T1.generate_vonmises(Positions().circular_positions(8, 5), speed= 3., kappa = 8, opts = opts, time = time)
+      self.assertTrue(True)

--- a/test/test_visualisations.py
+++ b/test/test_visualisations.py
@@ -1,0 +1,34 @@
+import unittest, os, re
+import numpy as np
+from numpy import testing
+from motbox import Track, Position
+
+from motbox import visualisations as vis
+
+track_data_path = os.path.join("test", "tracks", "T220.csv")
+
+COMPLETE = True
+
+class TestVisualisation(unittest.TestCase):
+  def setUp(self):
+    T1 = Track()
+    T1.load_from_csv(track_data_path)
+    self.T1 = T1
+
+
+  def tearDown(self):
+    # removes generated files so they are not left in .git by accident
+    for f in os.listdir("test"):
+      if re.search(".*(.png)|(.mp4)", f):
+        os.remove(os.path.join("test", f))
+
+
+  def test_plot(self):
+    vis.plot(self.T1.x, self.T1.y, os.path.join("test", "test_trajectory.png"))
+    self.assertTrue(True)
+
+
+  @unittest.skipUnless(COMPLETE, "Time consuming video generation")
+  def test_make_video(self):
+    vis.trajectory_video(self.T1, os.path.join("test", "test_video.mp4"))
+    self.assertTrue(True)


### PR DESCRIPTION
Changes to the Track class, generation of tracks and visualisations. 

Package now works with both experiments in the https://github.com/hejtmy/psu-mot, as it no longer loads moviepy and matplotlib immediately (which was crashing my version of psychopy). Works with psychopy 2 and psychopy 3 with Python 2.7. The included `generate_straight_trajectory` and other scripts are used in the psu-mot python scripts which generate protocols and trajectories for the drew 2009 replication (https://github.com/hejtmy/psu-mot/tree/master/mot-drew-2009/generators)

## Main changes
- Allows generation of tracks with items of varying speed (e.g. one item moves at speed 1, other at speed 0.5, third at 0 etc.)
- adds generators to easily create tracks for experiments
- adds  `click` option to generate trajectory from a command line
- separates visualisations from the track and position to a `visualisations.py`, so Track and Position classes can be loaded without matplotlib and moviepy present

## Other changes
- adds a lot of documentation to the most complex functions (e.g. generate trajectory)
- new `generate_trajectory` generates straight trajectories and vonmises trajectory only adds a "jitter"
- Adds a lot of documentation to existing fuctions
- adds delimiter option to the load_csv